### PR TITLE
Support for basestation siren and user defined modes

### DIFF
--- a/arlo.js
+++ b/arlo.js
@@ -119,22 +119,33 @@ module.exports = function(RED) {
                     }
                     case "mode":
                     default: {
-                        if (msg.payload) {
-                            device.arm(function(body) {
+                        if (typeof msg.payload == "string") {
+                            device.setMode(msg.payload, function(body) {
                                 if (!body.success) {
                                     self.error(body)
                                 } else {
                                     self.send(msg)
                                 }
                             })
-                        } else {
-                            device.disarm(function(body) {
-                                if (!body.success) {
-                                    self.error(body)
-                                } else {
-                                    self.send(msg)
-                                }
-                            })
+                        }
+                        else {
+                            if (msg.payload) {
+                                device.arm(function(body) {
+                                    if (!body.success) {
+                                        self.error(body)
+                                    } else {
+                                        self.send(msg)
+                                    }
+                                })
+                            } else {
+                                device.disarm(function(body) {
+                                    if (!body.success) {
+                                        self.error(body)
+                                    } else {
+                                        self.send(msg)
+                                    }
+                                })
+                            }
                         }
                         break
                     }

--- a/arlo.js
+++ b/arlo.js
@@ -95,24 +95,50 @@ module.exports = function(RED) {
 
 				var device = self.config.arlo.devices[n.device]
 
-				if (msg.payload) {
-					device.arm(function(body) {
-						if (!body.success) {
-							self.error(body)
-						} else {
-							self.send(msg)
-						}
-					})
-				} else {
-					device.disarm(function(body) {
-						if (!body.success) {
-							self.error(body)
-						} else {
-							self.send(msg)
-						}
-					})
-				}
-
+                switch (msg.topic)
+                {
+                    case "siren": {
+                        if (msg.payload) {
+                            device.alarmOn(function(body) {
+                                if (!body.success) {
+                                    self.error(body)
+                                } else {
+                                    self.send(msg)
+                                }
+                            })
+                        } else {
+                            device.alarmOff(function(body) {
+                                if (!body.success) {
+                                    self.error(body)
+                                } else {
+                                    self.send(msg)
+                                }
+                            })
+                        }
+                        break
+                    }
+                    case "mode":
+                    default: {
+                        if (msg.payload) {
+                            device.arm(function(body) {
+                                if (!body.success) {
+                                    self.error(body)
+                                } else {
+                                    self.send(msg)
+                                }
+                            })
+                        } else {
+                            device.disarm(function(body) {
+                                if (!body.success) {
+                                    self.error(body)
+                                } else {
+                                    self.send(msg)
+                                }
+                            })
+                        }
+                        break
+                    }
+                }
 			} else {
 				self.error('Service not ready')
 				self.config.init()

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   }
  },
  "dependencies": {
-  "node-arlo": "0.0.4"
+  "node-arlo": "^1.3.1"
  },
  "keywords": [
   "node-red",


### PR DESCRIPTION
This pull request introduces support for switching on/off the basestation siren (using the new version of node-arlo) and support for user defined modes (modes that the user has defined additionally to the default modes 'armed' and 'disarmed').